### PR TITLE
feat: trigger completion for dependencies only

### DIFF
--- a/lua/blink-cmp-npm/init.lua
+++ b/lua/blink-cmp-npm/init.lua
@@ -1,6 +1,7 @@
 local compute_meta = require("blink-cmp-npm.utils.compute_meta")
 local generate_doc = require("blink-cmp-npm.utils.generate_doc")
 local ignore_version = require("blink-cmp-npm.utils.ignore_version")
+local is_cursor_in_dependencies_node = require("blink-cmp-npm.utils.is_cursor_in_dependencies_node")
 local semantic_sort = require("blink-cmp-npm.utils.semantic_sort")
 
 ---@module 'blink.cmp'
@@ -35,6 +36,12 @@ function source:get_trigger_characters()
 end
 
 function source:get_completions(ctx, callback)
+  local is_in_dependencies_node = is_cursor_in_dependencies_node()
+
+  if not is_in_dependencies_node then
+    return function() end
+  end
+
   local meta = compute_meta(ctx)
   local _, name, _, _, pos_third_quote, _, current_version, current_version_matcher, _, find_version = unpack(meta)
 

--- a/lua/blink-cmp-npm/utils/is_cursor_in_dependencies_node.lua
+++ b/lua/blink-cmp-npm/utils/is_cursor_in_dependencies_node.lua
@@ -1,0 +1,32 @@
+local ts_parsers = require("nvim-treesitter.parsers")
+local ts_utils = require("nvim-treesitter.ts_utils")
+
+---@return boolean
+local function is_cursor_in_dependencies_node()
+  local bufnr = vim.api.nvim_get_current_buf()
+
+  -- not blocking completion if there is no parser for JSON
+  if not ts_parsers.has_parser("json") then
+    return true
+  end
+
+  local node = ts_utils.get_node_at_cursor()
+
+  while node do
+    local node_type = node:type()
+    if node_type == "pair" then
+      local key_node = node:child(0)
+      if key_node and key_node:type() == "string" then
+        local key_text = vim.treesitter.get_node_text(key_node, bufnr)
+        if key_text == '"dependencies"' or key_text == '"devDependencies"' then
+          return true
+        end
+      end
+    end
+    node = node:parent()
+  end
+
+  return false
+end
+
+return is_cursor_in_dependencies_node

--- a/lua/blink-cmp-npm/utils/is_cursor_in_dependencies_node_headlessspec.lua
+++ b/lua/blink-cmp-npm/utils/is_cursor_in_dependencies_node_headlessspec.lua
@@ -1,0 +1,71 @@
+-- Environement setup
+local data_path = vim.fn.stdpath("data")
+
+vim.opt.runtimepath:append(data_path .. "/lazy/nvim-treesitter")
+vim.opt.runtimepath:append(vim.fn.getcwd())
+
+local is_cursor_in_dependencies_node = require("blink-cmp-npm.utils.is_cursor_in_dependencies_node")
+local parsers = require("nvim-treesitter.parsers")
+local ts_configs = require("nvim-treesitter.configs")
+local path = "package.json"
+
+ts_configs.setup({
+  ensure_installed = { "json" },
+  highlight = { enable = false },
+})
+
+local force_parsing = function()
+  local buf = vim.api.nvim_get_current_buf()
+  local lang = parsers.get_buf_lang(buf)
+  local parser = parsers.get_parser(buf, lang)
+  parser:parse()
+end
+
+local create_file = function()
+  local file = io.open(path, "w")
+  local package_json = [[
+{
+  "name": "test-package",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "typescript": "^4.6.3"
+  }
+}
+]]
+
+  assert(file, "Failed to open file for writing")
+  file:write(package_json)
+  file:close()
+end
+
+local cleanup_file = function()
+  os.remove(path)
+end
+
+describe("is_cursor_in_dependencies_node", function()
+  create_file()
+  vim.cmd("edit " .. path)
+
+  it("should detect cursor in dependencies", function()
+    force_parsing()
+
+    vim.api.nvim_win_set_cursor(0, { 4, 5 })
+    local result = is_cursor_in_dependencies_node()
+    assert.is_true(result)
+  end)
+
+  it("should detect cursor in devDependencies", function()
+    vim.api.nvim_win_set_cursor(0, { 7, 5 })
+    local result = is_cursor_in_dependencies_node()
+    assert.is_true(result)
+  end)
+
+  it("should detect cursor outside of dependencies or devDependencies", function()
+    vim.api.nvim_win_set_cursor(0, { 7, 5 })
+    local result = is_cursor_in_dependencies_node()
+    assert.is_true(result)
+  end)
+  cleanup_file()
+end)

--- a/run-headless-tests.sh
+++ b/run-headless-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+for file in $(find lua/blink-cmp-npm -name '*_headlessspec.lua'); do
+  echo "Running tests in: $file"
+  nvim --headless -c "PlenaryBustedFile $file" -c "qa"
+done


### PR DESCRIPTION
### Issue
Currently the completion for packages names and versions triggers when editing properties different than dependencies in `package.json.`

### Solution
Using treesitter check if cursor is inside `dependencies` or `devDependencies` json node, and trigger completion only in if it is.